### PR TITLE
Exit autoscaler when evaluation fails to allow nomad to restart

### DIFF
--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -87,6 +88,7 @@ func (w *BaseWorker) Run(ctx context.Context) {
 		// Notify broker that policy eval was successful.
 		if err := w.broker.Ack(eval.ID, token); err != nil {
 			logger.Warn("failed to ACK policy evaluation", "err", err)
+			os.Exit(1)
 		}
 	}
 }


### PR DESCRIPTION
Currently, the autoscaler can often get completely hamstrung when failing to acknowledge a policy evaluation. When this occurs, the queue worker fails to continue performing any work and the autoscaler must be manually restarted to continue its job.

If the process exits, then nomad will automatically restart the service and it will continue work as normal.